### PR TITLE
feat: rename package to `@tmjssz/jsonresume-theme-even` and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jsonresume-theme-even
+# @tmjssz/jsonresume-theme-even
 
 [![npm package version](https://img.shields.io/npm/v/jsonresume-theme-even.svg)](https://www.npmjs.com/package/jsonresume-theme-even)
 [![Build status](https://img.shields.io/github/actions/workflow/status/rbardini/jsonresume-theme-even/main.yml)](https://github.com/rbardini/jsonresume-theme-even/actions)
@@ -22,7 +22,7 @@ Inspired by [jsonresume-theme-flat](https://github.com/erming/jsonresume-theme-f
 ## Installation
 
 ```console
-npm install jsonresume-theme-even
+npm install @tmjssz/jsonresume-theme-even
 ```
 
 ## Usage
@@ -41,7 +41,7 @@ npx resume export resume.html
 [Resumed](https://github.com/rbardini/resumed) requires you to install the theme, since it does not come with any by default. It will then automatically load and use _Even_ when rendering a resume:
 
 ```console
-npm install resumed jsonresume-theme-even
+npm install resumed @tmjssz/jsonresume-theme-even
 npx resumed render
 ```
 
@@ -50,7 +50,7 @@ npx resumed render
 _Even_ comes with a barebones CLI that reads resumes from `stdin` and outputs HTML to `stdout`. This allows usage without any resume builder tools:
 
 ```console
-npx jsonresume-theme-even < resume.json > resume.html
+npx @tmjssz/jsonresume-theme-even < resume.json > resume.html
 ```
 
 ## Options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "jsonresume-theme-even",
-  "version": "0.23.0",
+  "name": "@tmjssz/jsonresume-theme-even",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "jsonresume-theme-even",
-      "version": "0.23.0",
+      "name": "@tmjssz/jsonresume-theme-even",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@rbardini/html": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "jsonresume-theme-even",
-  "version": "0.23.0",
+  "name": "@tmjssz/jsonresume-theme-even",
+  "version": "0.1.0",
   "description": "A flat JSON Resume theme, compatible with the latest resume schema",
   "keywords": [
     "resume",
@@ -10,16 +10,11 @@
     "curriculum-vitae",
     "cv"
   ],
-  "homepage": "https://jsonresume-theme-even.rbrd.in/",
-  "bugs": {
-    "url": "https://github.com/rbardini/jsonresume-theme-even/issues"
-  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rbardini/jsonresume-theme-even.git"
+    "url": "git+https://github.com/tmjssz/jsonresume-theme-even"
   },
   "license": "MIT",
-  "author": "Rafael Bardini",
   "type": "module",
   "exports": {
     ".": {
@@ -39,7 +34,7 @@
   "source": "index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "jsonresume-theme-even": "bin/cli.js"
+    "@tmjssz/jsonresume-theme-even": "bin/cli.js"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This pull request includes changes to update the package name and related references from `jsonresume-theme-even` to `@tmjssz/jsonresume-theme-even`. The most important changes include modifications to the `README.md` and `package.json` files to reflect the new package name and repository URL.

Updates to package name and references:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1): Updated the package name in various installation and usage instructions to `@tmjssz/jsonresume-theme-even`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R3): Changed the `name` field to `@tmjssz/jsonresume-theme-even`, updated the `version`, and modified the `repository` URL to point to the new GitHub repository. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-L22)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L42-R37): Updated the `bin` field to reflect the new package name for the CLI command.