### PR TITLE
chore: add workflow deploying a demo to Github Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 # Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy to Github Pages
 
 on:
   # Runs on pushes targeting the default branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,9 @@
 name: Deploy to Github Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the main branch
   push:
-    branches: ['main', 'feat/deploy-workflow']
+    branches: ['main']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+      - feat/deploy-workflow
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        uses: bahmutov/npm-install@v1
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload production-ready build files
+        uses: actions/upload-artifact@v3
+        with:
+          name: production-files
+          path: ./dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/feat/deploy-workflow'
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: production-files
+          path: ./dist
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,13 +22,13 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Build project
-        run: npm run build
+        run: npm run build-editor
 
       - name: Upload production-ready build files
         uses: actions/upload-artifact@v3
         with:
           name: production-files
-          path: ./dist
+          path: ./public
 
   deploy:
     name: Deploy
@@ -41,10 +41,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: production-files
-          path: ./dist
+          path: ./public
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ./public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ name: Deploy to Github Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ['feat/deploy-workflow']
+    branches: ['main', 'feat/deploy-workflow']
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   # Single deploy job since we're just deploying
   deploy:
+    name: Build and deploy
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,50 +1,51 @@
-name: Deploy
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
 
 on:
+  # Runs on pushes targeting the default branch
   push:
-    branches:
-      - main
-      - feat/deploy-workflow
+    branches: ['feat/deploy-workflow']
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets the GITHUB_TOKEN permissions to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v3
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-
-      - name: Install dependencies
-        uses: bahmutov/npm-install@v1
-
-      - name: Build project
-        run: npm run build-editor
-
-      - name: Upload production-ready build files
-        uses: actions/upload-artifact@v3
-        with:
-          name: production-files
-          path: ./public
-
+  # Single deploy job since we're just deploying
   deploy:
-    name: Deploy
-    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/feat/deploy-workflow'
-
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
-          name: production-files
-          path: ./public
-
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build-editor
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload public folder
+          path: './public'
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # @tmjssz/jsonresume-theme-even
 
+Fork of [jsonresume-theme-even](https://github.com/rbardini/jsonresume-theme-even).
+
 A flat [JSON Resume](https://jsonresume.org/) theme, compatible with the latest [resume schema](https://github.com/jsonresume/resume-schema).
 
-Fork of [jsonresume-theme-even](https://github.com/rbardini/jsonresume-theme-even).
+[View demo →](https://tmjssz.github.io/jsonresume-theme-even-compact/)
 
 - 💄 Markdown support
 - 📐 CSS grid layout

--- a/editor/index.html
+++ b/editor/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>jsonresume-theme-even</title>
+    <title>@tmjssz/jsonresume-theme-even</title>
     <meta name="description" content="A flat JSON Resume theme, compatible with the latest resume schema." />
     <meta name="viewport" content="width=device-width" />
     <script src="/editor.js" type="module"></script>
@@ -18,7 +18,7 @@
         </svg>
       </button>
       <a
-        href="https://github.com/rbardini/jsonresume-theme-even"
+        href="https://github.com/tmjssz/jsonresume-theme-even-compact"
         aria-label="Star on GitHub"
         title="Star on GitHub"
         target="_blank"

--- a/editor/vite.config.js
+++ b/editor/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig(({ mode }) => {
       outDir: '../public',
       target: 'esnext',
     },
+    base: '/jsonresume-theme-even-compact/public/',
     publicDir: false,
   }
 })

--- a/editor/vite.config.js
+++ b/editor/vite.config.js
@@ -6,7 +6,7 @@ export default defineConfig(({ mode }) => {
       outDir: '../public',
       target: 'esnext',
     },
-    base: '/jsonresume-theme-even-compact/public/',
+    base: '/jsonresume-theme-even-compact/',
     publicDir: false,
   }
 })


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying static content to GitHub Pages and includes several updates to the project documentation and configuration files. The most important changes are summarized below:

### Deployment Workflow

* Added a new GitHub Actions workflow (`.github/workflows/deploy.yml`) for deploying static content to GitHub Pages. This workflow is triggered by pushes to the main branch and can also be run manually. It includes steps for checking out the repository, setting up Node, installing dependencies, building the project, and deploying to GitHub Pages.
* Deploys the Github Page at https://tmjssz.github.io/jsonresume-theme-even-compact/ 

### Documentation Updates

* Updated the `README.md` file to move the fork attribution and add a link to the demo page.

### Configuration and Metadata Updates

* Changed the title in `editor/index.html` to reflect the new project name `@tmjssz/jsonresume-theme-even`.
* Updated the GitHub link in `editor/index.html` to point to the new repository URL.
* Modified the `base` configuration in `editor/vite.config.js` to set the correct base path for the project.