### PR TITLE
fix: work subtitle

### DIFF
--- a/components/sections/work.js
+++ b/components/sections/work.js
@@ -19,12 +19,13 @@ export function NestedWork({ breakBefore, description, name, url, items = [] }) 
   const hasSingleItem = items.length === 1
   const firstItem = items[0]
 
-  const title = hasSingleItem ? firstItem.position : Link(url, name)
+  const nameLink = Link(url, name)
+  const title = hasSingleItem ? firstItem.position : nameLink
   const subtitle = hasSingleItem
     ? html`
         <span>
-          <strong class="discrete-link color-primary">${Link(url, name)}</strong>
-          <span class="meta"> ${firstItem.location && html`· ${firstItem.location}`} </span>
+          <strong class="discrete-link color-primary">${nameLink}</strong>
+          ${firstItem.location && html`<span>${nameLink && '· '}${firstItem.location}</span>`}
         </span>
         <div>${firstItem.startDate && Duration(firstItem.startDate, firstItem.endDate)}</div>
       `

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tmjssz/jsonresume-theme-even",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tmjssz/jsonresume-theme-even",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@rbardini/html": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmjssz/jsonresume-theme-even",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A flat JSON Resume theme, compatible with the latest resume schema",
   "keywords": [
     "resume",

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -102,7 +102,7 @@ customElements.define('time-duration', TimeDuration)
           <div class="meta">
         <span>
           <strong class="discrete-link color-primary"><a href="http://piedpiper.example.com">Pied Piper</a></strong>
-          <span class="meta"> · Palo Alto, CA </span>
+          <span>· Palo Alto, CA</span>
         </span>
         <div><time-duration><time datetime="2013-12-01">Dec 2013</time> – <time datetime="2014-12-01">Dec 2014</time></time-duration></div>
       </div>


### PR DESCRIPTION
* [`components/sections/work.js`](diffhunk://#diff-c11f14d9494ede4bd8bae427e03616ff585cdf7550e5a60c1d7aaa49af225d67L22-R28): Fix layout of work subtitle if name and url are both missing. Refactored the `title` and `subtitle` logic to use a `nameLink` variable, improving readability and consistency.
* [`test/__snapshots__/index.test.js.snap`](diffhunk://#diff-bc9ee34e71b06608a203d9c4c4813cbaa69be3c41e3163db549103b5152575f1L105-R105): Updated the snapshot to reflect the changes in the `NestedWork` component, ensuring the test output matches the new format.

### Package version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.4.0` to `0.4.1` to reflect the latest changes.